### PR TITLE
add minimal versioning to serialized data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-all: build-all
+all: test build-all
+
+test:
+	go test -v ./...
 
 build-all:
 	mkdir -p build

--- a/internal/machine/machine001.go
+++ b/internal/machine/machine001.go
@@ -7,10 +7,14 @@ import (
 )
 
 func RunMachine001(XpPubKey []byte, XpSig []byte, XpMsg []byte) bool {
-	// TODO: bind opcodes to machine variant
-	// TODO: introduce a marker for a XpPubKey script and XpSig script
+	mc := MachineCode{}
+	err := mc.Deserialize(XpSig, CodeTypeXSig)
+	if err != nil {
+		log.Println("Deserialize", err)
+		return false
+	}
 	e := lowlevel.NewEval()
-	err := e.Eval(XpSig)
+	err = e.Eval(mc.Code)
 	if err != nil {
 		log.Println("Eval part 1", err)
 		return false
@@ -20,7 +24,12 @@ func RunMachine001(XpPubKey []byte, XpSig []byte, XpMsg []byte) bool {
 	e = lowlevel.NewEval()
 	e.Stack.S = intermediateStack
 
-	err = e.EvalWithXmsg(XpPubKey, XpMsg)
+	err = mc.Deserialize(XpPubKey, CodeTypeXPublicKey)
+	if err != nil {
+		log.Println("Deserialize:", err)
+		return false
+	}
+	err = e.EvalWithXmsg(mc.Code, XpMsg)
 	if err != nil {
 		log.Println("Eval part 2", err)
 		return false

--- a/internal/machine/machine001_test.go
+++ b/internal/machine/machine001_test.go
@@ -11,28 +11,28 @@ func TestRunMachine001(t *testing.T) {
 	msg := []byte("yolo")
 	_, publicKeyBytes, sig := crypto.HelperVerifyData(msg)
 
-	a := ll.Assembler{}
+	a := MachineCode{}
 	a.Append(ll.Push(sig))
 
-	xSig := a.Code
+	xSig := a.Serialize(CodeTypeXSig)
 
-	b := ll.Assembler{}
+	b := MachineCode{}
 	b.Append(ll.Push(publicKeyBytes))
 	b.Append(ll.SignatureVerify())
 
-	xPubKey := b.Code
+	xPubKey := b.Serialize(CodeTypeXPublicKey)
 
 	assert.True(t, RunMachine001(xPubKey, xSig, msg))
 }
 
 func helperTestMultisignature(msg, pk1, pk2, pk3, sig1, sig2 []byte) bool {
-	a := ll.Assembler{}
+	a := MachineCode{}
 	a.Append(ll.Push(sig1))
 	a.Append(ll.Push(sig2))
 
-	xSig := a.Code
+	xSig := a.Serialize(CodeTypeXSig)
 
-	b := ll.Assembler{}
+	b := MachineCode{}
 	b.Append(ll.Push(pk1))
 	b.Append(ll.Push(pk2))
 	b.Append(ll.Push(pk3))
@@ -41,7 +41,7 @@ func helperTestMultisignature(msg, pk1, pk2, pk3, sig1, sig2 []byte) bool {
 
 	b.Append(ll.MultisigVerify())
 
-	xPubKey := b.Code
+	xPubKey := b.Serialize(CodeTypeXPublicKey)
 
 	return RunMachine001(xPubKey, xSig, msg)
 }

--- a/internal/machine/machine_code.go
+++ b/internal/machine/machine_code.go
@@ -1,0 +1,47 @@
+package machines
+
+import (
+	"bytes"
+	"github.com/oreparaz/xsig/internal/lowlevel"
+	"github.com/pkg/errors"
+)
+
+type MachineCode struct {
+	lowlevel.Assembler
+}
+
+type MachineType uint8
+type CodeType uint8
+
+const (
+	GlobalMagic string = "xsig"
+)
+
+const (
+	MachineTypeMachine001 MachineType = 0
+)
+
+const (
+	CodeTypeXPublicKey CodeType = 0
+	CodeTypeXSig CodeType = 1
+)
+
+func prefix(codeType CodeType) []byte {
+	x := []byte(GlobalMagic)
+	x = append(x, byte(MachineTypeMachine001))
+	x = append(x, byte(codeType))
+	return x
+}
+
+func (m *MachineCode) Serialize(codeType CodeType) []byte {
+	return append(prefix(codeType), m.Code...)
+}
+
+func (m *MachineCode) Deserialize(x []byte, expectedCodeType CodeType) error {
+	expectedPrefix := prefix(expectedCodeType)
+	if !bytes.HasPrefix(x, expectedPrefix) {
+		return errors.New("wrong prefix")
+	}
+	m.Code = bytes.TrimPrefix(x, expectedPrefix)
+	return nil
+}

--- a/internal/machine/machine_code_test.go
+++ b/internal/machine/machine_code_test.go
@@ -1,0 +1,19 @@
+package machines
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSerialize(t *testing.T) {
+	a := MachineCode{}
+	xSig := a.Serialize(CodeTypeXSig)
+
+	b := MachineCode{}
+	err := b.Deserialize(xSig, CodeTypeXPublicKey)
+	assert.Error(t, err)
+
+	c := MachineCode{}
+	err = c.Deserialize(xSig, CodeTypeXSig)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Every serialized data is now persisted and bound to a machine type and a code type (`xsig` vs `xpublickey`), with the intention of catching mistakes earlier (like confusing an `xsig` for `xpublickey`). Closes #23 and #24.