### PR TITLE
feat: use compressed public keys

### DIFF
--- a/cmd/demo/demo.go
+++ b/cmd/demo/demo.go
@@ -68,9 +68,9 @@ func main() {
 	err  = os.WriteFile("public2.pem", pub2_s, 0644); check(err)
 	err  = os.WriteFile("public3.pem", pub3_s, 0644); check(err)
 
-	pk1Bytes := elliptic.Marshal(pub1.Curve, pub1.X, pub1.Y)
-	pk2Bytes := elliptic.Marshal(pub2.Curve, pub2.X, pub2.Y)
-	pk3Bytes := elliptic.Marshal(pub3.Curve, pub3.X, pub3.Y)
+	pk1Bytes := elliptic.MarshalCompressed(pub1.Curve, pub1.X, pub1.Y)
+	pk2Bytes := elliptic.MarshalCompressed(pub2.Curve, pub2.X, pub2.Y)
+	pk3Bytes := elliptic.MarshalCompressed(pub3.Curve, pub3.X, pub3.Y)
 
 	// part 2: create the lock script / xPublickey for a 2-of-3 multisig
 	xPublicKey := machines.MachineCode{}

--- a/internal/crypto/helperstest.go
+++ b/internal/crypto/helperstest.go
@@ -18,7 +18,7 @@ func HelperVerifyData(msg []byte) (privateKey *ecdsa.PrivateKey, publicKeyBytes 
 
 	pk := privateKey.PublicKey
 	// 65 bytes always
-	publicKeyBytes = elliptic.Marshal(pk.Curve, pk.X, pk.Y)
+	publicKeyBytes = elliptic.MarshalCompressed(pk.Curve, pk.X, pk.Y)
 
 	return privateKey, publicKeyBytes, sig
 }

--- a/internal/crypto/signatures.go
+++ b/internal/crypto/signatures.go
@@ -8,7 +8,7 @@ import (
 
 func VerifySignature(msg []byte, publicKeyBytes []byte, sig []byte) bool {
 	hash := sha256.Sum256([]byte(msg))
-	x,y :=  elliptic.Unmarshal(elliptic.P256(), publicKeyBytes)
+	x,y :=  elliptic.UnmarshalCompressed(elliptic.P256(), publicKeyBytes)
 	pku := ecdsa.PublicKey{
 		Curve: elliptic.P256(),
 		X:     x,

--- a/internal/lowlevel/builtin_words.go
+++ b/internal/lowlevel/builtin_words.go
@@ -51,7 +51,7 @@ func (e *Eval) not() error {
 }
 
 func (e *Eval) sigverify(xmsg []byte) error {
-	publicKey, err := e.Stack.PopPublicKey()
+	publicKey, err := e.Stack.PopPublicKeyCompressed()
 	if err != nil {
 		return errors.Wrapf(err, "PopPublicKey")
 	}
@@ -83,7 +83,7 @@ func (e *Eval) multisigverify(xmsg []byte) error {
 
 	pk := make([][]byte, nPublicKeys)
 	for i:=0; i < int(nPublicKeys); i++ {
-		pk[i], err = e.Stack.PopPublicKey()
+		pk[i], err = e.Stack.PopPublicKeyCompressed()
 		if err != nil {
 			return errors.Wrapf(err, "PopPublicKey")
 		}

--- a/internal/lowlevel/stack_test.go
+++ b/internal/lowlevel/stack_test.go
@@ -45,7 +45,7 @@ func TestStack_PopPublicKey(t *testing.T) {
 	s := Stack{}
 	s.PushBytes([]byte("garbage"))
 	s.PushBytes(reverse(pk))
-	pkRead, err := s.PopPublicKey()
+	pkRead, err := s.PopPublicKeyCompressed()
 	assert.Nil(t, err)
 	assert.Equal(t, pk, reverse(pkRead))
 }


### PR DESCRIPTION
This saves about half of xpublickey space. Before, a 2-of-3 multisig took this much:

78736967000003411fe9dc72e327363a0e801ef3aad3bf0c57610f05f8e0ed515f7e3a7b4dcfc597c582859e57e9a65214d9b41ee5334deb4c31b039718d510aba4b0f995fe69b80040341179f1d68dbe1384e59c8d65c1864076b720da0a0ca3af31b23a78d5ba8e5836090cc44265296e5c0393149590c44bf250d470fae6d60342df145e238e4599f98040341876a7936392694077202870952794194c42c9052377245cebc49e0e10a6d8a218d77681d5e45ad7acd59047ea86793e53677f383339602e56c1daea9dbfa92d10403010203010305

After, it’s almost half:
 
7873696700000321416a2c5d1117510d919ddd057ae079292bf9e2c3e931df8f30ae521bfda7d51703032150c19e29e9beb24cd71fe76c1e8a4ec1e300aaa781ef5433b45f63aa2d13282f030321a2634de07595fe0644ab29465015fd8f5491ee4eb0589c6c030c524247e34c490203010203010305

Closes #20.